### PR TITLE
Token require fix when requireToken is set to false

### DIFF
--- a/src/TokenAuthorizator.php
+++ b/src/TokenAuthorizator.php
@@ -38,7 +38,7 @@ final class TokenAuthorizator implements MatchExtension
 		if (
 			$this->strategy->isActive() === false
 			|| $this->isPublicAccess($endpoint)
-			|| $this->isTokenOk()
+			|| $this->isTokenOk($params['token'] ?? null)
 		) {
 			return null;
 		}
@@ -73,9 +73,8 @@ final class TokenAuthorizator implements MatchExtension
 	}
 
 
-	private function isTokenOk(): bool
+	private function isTokenOk(mixed $token): bool
 	{
-		$token = $params['token'] ?? null;
 		if ($token === null) {
 			throw new \InvalidArgumentException('Parameter "token" is required.');
 		}

--- a/src/TokenAuthorizator.php
+++ b/src/TokenAuthorizator.php
@@ -38,13 +38,7 @@ final class TokenAuthorizator implements MatchExtension
 		if ($this->strategy->isActive() === false) {
 			return null;
 		}
-		$token = $params['token'] ?? null;
-		if ($token === null) {
-			throw new \InvalidArgumentException('Parameter "token" is required.');
-		}
-		if (is_string($token) === false) {
-			throw new \InvalidArgumentException(sprintf('Parameter "token" must be string, but type "%s" given.', get_debug_type($token)));
-		}
+
 		$requireToken = false;
 		try {
 			$ref = new \ReflectionClass($endpoint);
@@ -53,6 +47,7 @@ final class TokenAuthorizator implements MatchExtension
 				return null;
 			}
 			foreach ($ref->getAttributes(PublicEndpoint::class) as $publicEndpointAttribute) {
+				bdump($publicEndpointAttribute->getArguments());
 				if (($publicEndpointAttribute->getArguments()['requireToken'] ?? false) === true) {
 					$requireToken = true;
 				}
@@ -64,6 +59,15 @@ final class TokenAuthorizator implements MatchExtension
 				$e,
 			);
 		}
+
+		$token = $params['token'] ?? null;
+		if ($token === null && $requireToken === true) {
+			throw new \InvalidArgumentException('Parameter "token" is required.');
+		}
+		if (is_string($token) === false && $requireToken === true) {
+			throw new \InvalidArgumentException(sprintf('Parameter "token" must be string, but type "%s" given.', get_debug_type($token)));
+		}
+
 		if ($requireToken === false || $this->strategy->verify($token)) {
 			return null;
 		}

--- a/src/TokenAuthorizator.php
+++ b/src/TokenAuthorizator.php
@@ -35,41 +35,14 @@ final class TokenAuthorizator implements MatchExtension
 	 */
 	public function beforeProcess(Endpoint $endpoint, array $params, string $action, string $method): ?Response
 	{
-		if ($this->strategy->isActive() === false) {
+		if (
+			$this->strategy->isActive() === false
+			|| $this->isPublicAccess($endpoint)
+			|| $this->isTokenOk()
+		) {
 			return null;
 		}
 
-		$requireToken = false;
-		try {
-			$ref = new \ReflectionClass($endpoint);
-			$docComment = trim((string) $ref->getDocComment());
-			if (preg_match('/@public(?:$|\s|\n)/', $docComment) === 1) {
-				return null;
-			}
-			foreach ($ref->getAttributes(PublicEndpoint::class) as $publicEndpointAttribute) {
-				if (($publicEndpointAttribute->getArguments()['requireToken'] ?? false) === true) {
-					$requireToken = true;
-				}
-			}
-		} catch (\ReflectionException $e) {
-			throw new \InvalidArgumentException(
-				sprintf('Endpoint "%s" can not be reflected: %s', $endpoint::class, $e->getMessage()),
-				500,
-				$e,
-			);
-		}
-
-		$token = $params['token'] ?? null;
-		if ($token === null && $requireToken === true) {
-			throw new \InvalidArgumentException('Parameter "token" is required.');
-		}
-		if (is_string($token) === false && $requireToken === true) {
-			throw new \InvalidArgumentException(sprintf('Parameter "token" must be string, but type "%s" given.', get_debug_type($token)));
-		}
-
-		if ($requireToken === false || $this->strategy->verify($token)) {
-			return null;
-		}
 		throw new \InvalidArgumentException('Token is invalid or expired, please contact your administrator.');
 	}
 
@@ -80,5 +53,36 @@ final class TokenAuthorizator implements MatchExtension
 	public function afterProcess(Endpoint $endpoint, array $params, ?Response $response): ?Response
 	{
 		return null;
+	}
+
+
+	private function isPublicAccess(Endpoint $endpoint): bool
+	{
+		$requireToken = false;
+		$ref = new \ReflectionClass($endpoint);
+		if (str_contains((string) $ref->getDocComment(), '@public')) {
+			return true;
+		}
+		foreach ($ref->getAttributes(PublicEndpoint::class) as $publicEndpointAttribute) {
+			if (($publicEndpointAttribute->getArguments()['requireToken'] ?? false) === true) {
+				$requireToken = true;
+			}
+		}
+
+		return $requireToken === false;
+	}
+
+
+	private function isTokenOk(): bool
+	{
+		$token = $params['token'] ?? null;
+		if ($token === null) {
+			throw new \InvalidArgumentException('Parameter "token" is required.');
+		}
+		if (is_string($token) === false) {
+			throw new \InvalidArgumentException(sprintf('Parameter "token" must be string, but type "%s" given.', get_debug_type($token)));
+		}
+
+		return $this->strategy->verify($token);
 	}
 }

--- a/src/TokenAuthorizator.php
+++ b/src/TokenAuthorizator.php
@@ -47,7 +47,6 @@ final class TokenAuthorizator implements MatchExtension
 				return null;
 			}
 			foreach ($ref->getAttributes(PublicEndpoint::class) as $publicEndpointAttribute) {
-				bdump($publicEndpointAttribute->getArguments());
 				if (($publicEndpointAttribute->getArguments()['requireToken'] ?? false) === true) {
 					$requireToken = true;
 				}


### PR DESCRIPTION
- bug fix / new feature?   bug fix
- BC break? yes/no no

When endpoint has `#[PublicEndpoint(requireToken: false)]` notation and URL is not using that parameter, authorizator throws error and require token to be part of